### PR TITLE
Fix zcml condition of global_sections viewlet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 0.10.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix zcml condition for registering the global_sections viewlet. It was adding two different viewlets simultaneously on Plone 5, now one of those is gone.
+  [pnicolli]
 
 
 0.10.2 (2017-09-13)

--- a/src/collective/editablemenu/browser/configure.zcml
+++ b/src/collective/editablemenu/browser/configure.zcml
@@ -20,7 +20,7 @@
 
 
   <browser:viewlet
-      zcml:condition="have plone-4"
+      zcml:condition="not-have plone-5"
       name="plone.global_sections"
       manager="plone.app.layout.viewlets.interfaces.IPortalHeader"
       class=".viewlets.CustomGlobalSectionsViewlet"


### PR DESCRIPTION
The addon was adding two global_sections viewlets on Plone 5, now the one aimed at Plone 4 is really gone and only one of those is added :)