### PR TITLE
Remove protect script from submenu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 - Fix zcml condition for registering the global_sections viewlet. It was adding two different viewlets simultaneously on Plone 5, now one of those is gone.
   [pnicolli]
+- plone.protect js script was being added to the submenu html, now it's removed manually from the async response.
+  [pnicolli]
 
 
 0.10.2 (2017-09-13)

--- a/src/collective/editablemenu/browser/static/editablemenu.js
+++ b/src/collective/editablemenu/browser/static/editablemenu.js
@@ -61,7 +61,9 @@
       }
       // var baseUrl = portal_url ? portal_url : $('body').data().baseUrl;
       $.get(baseUrl + "/@@submenu_detail_view?tab_id=" + tabid, function(data) {
-        var result_html = $('<div id="submenu-details" class="submenu-' + tabid +'" style="display: none;"></div>').html(data);
+        var scriptRegex = /<script.*?id="protect-script".*?<\/script>/g;
+        var newData = data.replace(scriptRegex, '');
+        var result_html = $('<div id="submenu-details" class="submenu-' + tabid +'" style="display: none;"></div>').html(newData);
         if ($(result_html).children().length === 0) {
           //no results.
           return;


### PR DESCRIPTION
plone.protect js script was being added to the submenu html, now it's removed manually from the async response.